### PR TITLE
Fixed issue with nvim crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Please ignore the fact the numbers don't add up.
 ### `require'weather'`
 | Function | Args | Returns | Notes |
 | -------- | ---- | ------- | ----- | 
-| `location_lookup` | | `Location` | Looks up the user's location based on ip address. Uses `ip-api.com` |
+| `location_lookup` | `callback` A callback accepting a `Location` | | Looks up the user's location based on ip address. Uses `ip-api.com` |
 | `subscribe` | `id`: Any type that is unique. Used with `unsubscribe`<br>`callback`: A function accepting a `WeatherResult`| | Subscribes to all updates. `callback` may be called immediately with the last weather update if it exists. |
 
 ### 'require'weather.sources.openweathermap'`


### PR DESCRIPTION
Currently, nvim is crashing whenever the timer triggers an update. I'm not exactly sure why this is happening, but it seems like the issue is related to us doing a network request on the timer thread, which is problematic as is.

The solution is to delay the handling of the location request to `curl`'s `callback`. This both resolves the problem, and makes it more async. Additionally, I removed the first call to `update_weather()` in favor of starting the timer at `0`.

Tested locally with `update_interval = 5000`, and it has been running well so far.